### PR TITLE
Added deactivating bias-T in rtl_(adsb|fm|power|tcp) on exit.

### DIFF
--- a/src/rtl_adsb.c
+++ b/src/rtl_adsb.c
@@ -500,6 +500,11 @@ int main(int argc, char **argv)
 	if (file != stdout) {
 		fclose(file);}
 
+	if (enable_biastee) {
+		rtlsdr_set_bias_tee(dev, 0);
+		fprintf(stderr, "deactivated bias-T on GPIO PIN 0\n");
+	}
+
 	rtlsdr_close(dev);
 	free(buffer);
 	return r >= 0 ? r : -r;

--- a/src/rtl_fm.c
+++ b/src/rtl_fm.c
@@ -1266,6 +1266,11 @@ int main(int argc, char **argv)
 	if (output.file != stdout) {
 		fclose(output.file);}
 
+	if (enable_biastee) {
+		rtlsdr_set_bias_tee(dongle.dev, 0);
+		fprintf(stderr, "deactivated bias-T on GPIO PIN 0\n");
+	}
+
 	rtlsdr_close(dongle.dev);
 	return r >= 0 ? r : -r;
 }

--- a/src/rtl_power.c
+++ b/src/rtl_power.c
@@ -994,6 +994,11 @@ int main(int argc, char **argv)
 	if (file != stdout) {
 		fclose(file);}
 
+	if (enable_biastee) {
+		rtlsdr_set_bias_tee(dev, 0);
+		fprintf(stderr, "deactivated bias-T on GPIO PIN 0\n");
+	}
+
 	rtlsdr_close(dev);
 	free(fft_buf);
 	free(window_coefs);

--- a/src/rtl_tcp.c
+++ b/src/rtl_tcp.c
@@ -605,6 +605,11 @@ int main(int argc, char **argv)
 	}
 
 out:
+	if (enable_biastee) {
+		rtlsdr_set_bias_tee(dev, 0);
+		fprintf(stderr, "deactivated bias-T on GPIO PIN 0\n");
+	}
+
 	rtlsdr_close(dev);
 	closesocket(listensocket);
 	closesocket(s);


### PR DESCRIPTION
Fixes: 18bf269

Agreed, could you move this to the deinitialization routine of librtlsdr instead of every commandline utility?